### PR TITLE
Fix wireless adapter MAC address changing issues

### DIFF
--- a/macchanger.py
+++ b/macchanger.py
@@ -27,39 +27,134 @@ def get_adapter_info(adapter_name):
         return None
     
     adapter = adapters[0]
+    print(f"Debug - PNPDeviceID: {adapter.PNPDeviceID}")
+    
+    # Use CurrentControlSet instead of ControlSet001
     reg_base = r"SYSTEM\CurrentControlSet\Control\Class\{4D36E972-E325-11CE-BFC1-08002BE10318}"
     
+    # Extract adapter information for different matching methods
+    device_id = adapter.PNPDeviceID.split("\\")[-1] if adapter.PNPDeviceID else None
+    adapter_guid = None
+    
+    # Try to find the adapter configuration in the registry using multiple methods
     try:
         with winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, reg_base, 0, winreg.KEY_READ) as base_key:
             for i in range(256):
                 try:
                     subkey_name = winreg.EnumKey(base_key, i)
                     with winreg.OpenKey(base_key, subkey_name, 0, winreg.KEY_READ) as subkey:
+                        # Method 1: Match by DriverDesc (most common)
                         try:
                             driver_desc = winreg.QueryValueEx(subkey, "DriverDesc")[0]
                             if driver_desc == adapter.Name:
+                                print(f"Found adapter by DriverDesc: {driver_desc}")
                                 return adapter, f"{reg_base}\\{subkey_name}"
                         except WindowsError:
-                            continue
+                            pass
+                        
+                        # Method 2: Match by DeviceInstanceID or PNPDeviceID
+                        try:
+                            if device_id:
+                                device_instance_id = winreg.QueryValueEx(subkey, "DeviceInstanceID")[0]
+                                if device_id in device_instance_id:
+                                    print(f"Found adapter by DeviceInstanceID: {device_instance_id}")
+                                    return adapter, f"{reg_base}\\{subkey_name}"
+                        except WindowsError:
+                            pass
+                        
+                        # Method 3: Match by partial name (for cases where names don't match exactly)
+                        try:
+                            adapter_name_lower = adapter.Name.lower()
+                            driver_desc = winreg.QueryValueEx(subkey, "DriverDesc")[0].lower()
+                            # Check if significant parts of the name match (not just common words like "adapter")
+                            if (adapter_name_lower in driver_desc or 
+                                driver_desc in adapter_name_lower or 
+                                any(word in driver_desc for word in adapter_name_lower.split() if len(word) > 4)):
+                                print(f"Found adapter by partial name match: {driver_desc}")
+                                return adapter, f"{reg_base}\\{subkey_name}"
+                        except WindowsError:
+                            pass
+                            
                 except WindowsError:
                     break
     except WindowsError as e:
         print(f"Registry error: {e}")
-    return None
-
-def verify_mac_change(adapter_name, expected_mac):
-    """Verify MAC address change using Windows system commands."""
+    
+    # Try alternative method using NetCfgInstanceId for wireless adapters
     try:
-        output = subprocess.check_output("getmac /v /fo csv", shell=True).decode('utf-8')
-        for line in output.splitlines():
-            if line and adapter_name in line:
-                matches = re.search(r'([0-9A-F]{2}[-:]){5}([0-9A-F]{2})', line, re.IGNORECASE)
-                if matches:
-                    current_mac = matches.group(0).replace('-', '').replace(':', '').upper()
+        network_config_path = r"SYSTEM\CurrentControlSet\Control\Network\{4D36E972-E325-11CE-BFC1-08002BE10318}"
+        with winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, network_config_path, 0, winreg.KEY_READ) as network_key:
+            for i in range(256):
+                try:
+                    guid = winreg.EnumKey(network_key, i)
+                    connection_path = f"{network_config_path}\\{guid}\\Connection"
+                    
+                    # Skip virtual adapters and other non-relevant entries
+                    if guid == "Descriptions" or len(guid) < 10:
+                        continue
+                        
+                    try:
+                        with winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, connection_path, 0, winreg.KEY_READ) as conn_key:
+                            try:
+                                name = winreg.QueryValueEx(conn_key, "Name")[0]
+                                if adapter.NetConnectionID == name:
+                                    # Found the adapter's GUID, now find the corresponding registry key
+                                    with winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, reg_base, 0, winreg.KEY_READ) as class_key:
+                                        for j in range(256):
+                                            try:
+                                                subkey_name = winreg.EnumKey(class_key, j)
+                                                with winreg.OpenKey(class_key, subkey_name, 0, winreg.KEY_READ) as subkey:
+                                                    try:
+                                                        net_cfg_instance_id = winreg.QueryValueEx(subkey, "NetCfgInstanceId")[0]
+                                                        if net_cfg_instance_id.lower() == guid.lower():
+                                                            print(f"Found adapter by NetCfgInstanceId: {guid}")
+                                                            return adapter, f"{reg_base}\\{subkey_name}"
+                                                    except WindowsError:
+                                                        pass
+                                            except WindowsError:
+                                                break
+                            except WindowsError:
+                                pass
+                    except WindowsError:
+                        pass
+                except WindowsError:
+                    break
+    except WindowsError as e:
+        print(f"Network registry error: {e}")
+    
+    print("Could not find the adapter's registry key. MAC address change may fail.")
+    # As a last resort, return the adapter and a best guess for the registry path
+    return adapter, None
+
+def verify_mac_with_system_commands(adapter_name, expected_mac):
+    """Verify MAC address change using system commands (similar to ipconfig)."""
+    try:
+        # Run ipconfig /all and capture output
+        output = subprocess.check_output("ipconfig /all", shell=True, text=True)
+        
+        # Find the section for our adapter
+        adapter_section = None
+        lines = output.splitlines()
+        for i, line in enumerate(lines):
+            if adapter_name in line:
+                adapter_section = lines[i:i+20]  # Grab the next 20 lines which should include the MAC
+                break
+        
+        if not adapter_section:
+            return False
+        
+        # Look for Physical Address (MAC) in this section
+        for line in adapter_section:
+            if "Physical Address" in line:
+                # Extract MAC address (format: XX-XX-XX-XX-XX-XX)
+                mac_parts = line.split(":")
+                if len(mac_parts) >= 2:
+                    current_mac = mac_parts[1].strip().replace("-", "").upper()
                     return current_mac == expected_mac.upper()
+        
         return False
     except Exception as e:
-        print(f"Error verifying MAC: {str(e)}")
+        print(f"Error verifying MAC with system commands: {str(e)}")
         return False
 
 def change_mac_address(adapter_name, new_mac):
@@ -76,30 +171,88 @@ def change_mac_address(adapter_name, new_mac):
     adapter, reg_path = info
     print(f"Found adapter: {adapter.Name}")
     print(f"Current MAC: {adapter.MacAddress}")
+    
+    # Check if this is a wireless adapter
+    is_wireless = False
+    try:
+        # Using WMI to check if this is a wireless adapter
+        if hasattr(adapter, 'AdapterType') and adapter.AdapterType:
+            is_wireless = 'wireless' in adapter.AdapterType.lower()
+        
+        # Second method to check if wireless - look for specific names
+        if not is_wireless and adapter.Name:
+            is_wireless = any(term in adapter.Name.lower() for term in ['wireless', 'wifi', 'wi-fi', '802.11'])
+        
+        # Get NetConnectionID from the registry if available
+        if not is_wireless and hasattr(adapter, 'NetConnectionID') and adapter.NetConnectionID:
+            is_wireless = any(term in adapter.NetConnectionID.lower() for term in ['wireless', 'wifi', 'wi-fi'])
+    except:
+        pass
+    
+    # If this is a wireless adapter, ensure the MAC has correct format for Windows
+    if is_wireless:
+        print("Detected wireless adapter - ensuring MAC address format is compatible with Windows.")
+        # Check the first octet and modify if needed
+        first_byte = int(new_mac[0:2], 16)
+        # Windows requires the second bit to be set for wireless adapters
+        if first_byte & 0x02 == 0:
+            # Set the second bit (locally administered bit)
+            first_byte |= 0x02
+            new_mac = f"{first_byte:02X}{new_mac[2:]}".upper()
+            print(f"Adjusted MAC address to meet Windows wireless requirements: {new_mac}")
+    
+    if not reg_path:
+        print("Warning: Registry path not found. MAC address change may fail.")
+        return False
+        
+    print(f"Registry path: {reg_path}")
 
     try:
+        # Disable adapter
         print("Disabling adapter...")
         adapter.Disable()
-        time.sleep(2)
+        time.sleep(1)
 
+        # Change MAC in registry with full access rights
         print("Updating registry...")
-        with winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, reg_path, 0, winreg.KEY_ALL_ACCESS) as key:
-            winreg.SetValueEx(key, "NetworkAddress", 0, winreg.REG_SZ, new_mac.upper())
+        try:
+            with winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, reg_path, 0, winreg.KEY_ALL_ACCESS) as key:
+                winreg.SetValueEx(key, "NetworkAddress", 0, winreg.REG_SZ, new_mac.upper())
+                print("Registry update successful")
+        except WindowsError as e:
+            print(f"Registry error: {e}")
+            return False
 
+        # Re-enable adapter
         print("Enabling adapter...")
         adapter.Enable()
         time.sleep(5)
 
-        # Verify using both WMI and system commands
-        if verify_mac_change(adapter_name, new_mac):
-            print(f"MAC successfully changed to: {new_mac}")
-            return True
+        # Verify change using WMI
+        wmi_verification = False
+        system_verification = False
+        
+        adapters = wmi.WMI().Win32_NetworkAdapter(Name=adapter_name)
+        if adapters and adapters[0].MacAddress and adapters[0].MacAddress.replace(':', '') == new_mac.upper():
+            print(f"WMI reports MAC changed to: {adapters[0].MacAddress}")
+            wmi_verification = True
         else:
-            print("Warning: MAC change not reflected in system. You may need to restart your computer.")
-            return False
+            print("MAC change not reflected in WMI")
+        
+        # Verify with system commands (ipconfig-like)
+        if verify_mac_with_system_commands(adapter_name, new_mac):
+            print("System commands confirm MAC address change")
+            system_verification = True
+        else:
+            print("MAC change not reflected in system commands (ipconfig)")
+            print("You may need to manually disable and re-enable the adapter from Network Connections")
+        
+        # Return true only if at least one verification method succeeds
+        return wmi_verification or system_verification
 
     except Exception as e:
         print(f"Error: {str(e)}")
+        # Try to re-enable adapter if something went wrong
         try:
             adapter.Enable()
         except:
@@ -111,12 +264,13 @@ if __name__ == "__main__":
         ctypes.windll.shell32.ShellExecuteW(None, "runas", sys.executable, __file__, None, 1)
         sys.exit()
 
+    # List available adapters
     w = wmi.WMI()
     adapters = w.Win32_NetworkAdapter(PhysicalAdapter=True)
     
     print("Available adapters:")
     for i, adapter in enumerate(adapters):
-        if adapter.MacAddress:
+        if adapter.MacAddress:  # Only show adapters with MAC addresses
             print(f"{i + 1}. {adapter.Name} - {adapter.MacAddress}")
 
     choice = int(input("\nSelect adapter number: ")) - 1


### PR DESCRIPTION
   - Fixed wireless adapter MAC address changing by enforcing the correct format (02/06/0A/0E as first octet)
   - Added multiple registry path finding methods to handle various adapter types 
   - Improved verification with both WMI and ipconfig checks
   - Added longer timeout after adapter re-enable to ensure changes apply
   - Created requirements.txt file for dependency management